### PR TITLE
Update Linux build arguments

### DIFF
--- a/linux_args.gn
+++ b/linux_args.gn
@@ -22,12 +22,17 @@ enable_widevine = true
 
 # Faster builds at the cost of no debug symbols
 symbol_level = 0
+blink_symbol_level = 0
+enable_resource_allowlist_generation = false
 
 # Disable field trials (Yes, true = disabled)
-fieldtrial_testing_like_official_build = true
+disable_fieldtrial_testing_config = true
 
 # Disable remote control apis
 enable_remoting = false
 
-# Reporting is unused
-enable_reporting = false
+# Reporting is unused? (needs investigation)
+#enable_reporting = false
+
+# Native Client is dead
+enable_nacl = false


### PR DESCRIPTION
In order to get Hexavalent to build on Linux, I had to
* use `disable_fieldtrial_testing_config` in place of the old `fieldtrial_testing_like_official_build`,
* set `enable_nacl` to `false`, and
* remove `enable_reporting = false`.

After I did this and got a working build, I realized that most of these changes had already been made to the Windows build arguments. This pull request brings `linux_args.gn` into alignment with `windows_args.gn`, while keeping field trial testing disabled.