### PR TITLE
Use Google Chrome branding for client hints

### DIFF
--- a/patches/0042-use-Google-Chrome-branding-for-client-hints.patch
+++ b/patches/0042-use-Google-Chrome-branding-for-client-hints.patch
@@ -1,0 +1,24 @@
+From f7252846b8ce9be53062c9e2d9b843056705a809 Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <Zoraver@users.noreply.github.com>
+Date: Sun, 10 Oct 2021 21:59:16 -0400
+Subject: [PATCH] use Google Chrome branding for client hints
+
+---
+ components/embedder_support/user_agent_utils.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
+index 516504c2ce442..8bad5f494763d 100644
+--- a/components/embedder_support/user_agent_utils.cc
++++ b/components/embedder_support/user_agent_utils.cc
+@@ -136,6 +136,7 @@ const blink::UserAgentBrandList GetUserAgentBrandList(
+   int major_version_number;
+   base::StringToInt(major_version, &major_version_number);
+   absl::optional<std::string> brand;
++  brand = "Google Chrome";
+ #if !BUILDFLAG(CHROMIUM_BRANDING)
+   brand = version_info::GetProductName();
+ #endif
+-- 
+2.31.1
+


### PR DESCRIPTION
Addresses #32. Tested using Hexavalent 96.0.4664.45 on Fedora 34 and compared with Google Chrome 96.0.4664.45 running in the same environment.