### PR TITLE
Disable appending variations (x-client-data) header

### DIFF
--- a/patches/0042-disable-appending-variations-header.patch
+++ b/patches/0042-disable-appending-variations-header.patch
@@ -1,0 +1,28 @@
+From e60c4048f3207a8e3195a34ca014bf5a374e03d7 Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <Zoraver@users.noreply.github.com>
+Date: Sat, 15 Jan 2022 13:34:33 -0500
+Subject: [PATCH] disable appending variations header
+
+---
+ components/variations/net/variations_http_headers.cc | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/components/variations/net/variations_http_headers.cc b/components/variations/net/variations_http_headers.cc
+index bd47c250fe296..7184e48272dfc 100644
+--- a/components/variations/net/variations_http_headers.cc
++++ b/components/variations/net/variations_http_headers.cc
+@@ -100,10 +100,7 @@ URLValidationResult GetUrlValidationResult(const GURL& url) {
+ // Also, logs the result of validating |url| in histograms, one of which ends in
+ // |suffix|.
+ bool ShouldAppendVariationsHeader(const GURL& url, const std::string& suffix) {
+-  URLValidationResult result = GetUrlValidationResult(url);
+-  base::UmaHistogramEnumeration(
+-      "Variations.Headers.URLValidationResult." + suffix, result);
+-  return result == URLValidationResult::kShouldAppend;
++  return false;
+ }
+ 
+ // Returns true if the request is sent from a Google web property, i.e. from a
+-- 
+2.31.1
+


### PR DESCRIPTION
Addresses #71. Tested using Hexavalent 97.0.4692.71 on Fedora 34 with <https://chrome.google.com> and <https://www.youtube.com> as test cases. Before applying this patch, I observed the `x-client-data` header be sent to these domains. After applying this patch, I have not observed the `x-client-data` header be sent.