### PR TITLE
Build with full LTO and enable process isolated sandboxed iframes

### DIFF
--- a/patches/0041-build-with-full-LTO.patch
+++ b/patches/0041-build-with-full-LTO.patch
@@ -1,0 +1,32 @@
+From b72e65b26cddcc46f45d7ec86c4ce81631917933 Mon Sep 17 00:00:00 2001
+From: June <june@eridan.me>
+Date: Sun, 8 May 2022 01:36:58 +0000
+Subject: [PATCH] build with full LTO
+
+Signed-off-by: June <june@eridan.me>
+---
+ build/config/compiler/BUILD.gn | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index c219f78bdfb99..61c8b0cfd7b9e 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -660,7 +660,7 @@ config("compiler") {
+   if (!is_debug && use_thin_lto && is_a_target_toolchain) {
+     assert(use_lld, "LTO is only supported with lld")
+ 
+-    cflags += [ "-flto=thin" ]
++    cflags += [ "-flto=full" ]
+     if (!is_mac) {
+       # TODO(lgrey): Enable unit splitting for Mac when supported.
+       cflags += [ "-fsplit-lto-unit" ]
+@@ -683,7 +683,7 @@ config("compiler") {
+         "/lldltocachepolicy:$cache_policy",
+       ]
+     } else {
+-      ldflags += [ "-flto=thin" ]
++      ldflags += [ "-flto=full" ]
+ 
+       # Enabling ThinLTO on Chrome OS too, in an effort to reduce the memory
+       # usage in crbug.com/1038040. Note this will increase build time in

--- a/patches/0042-enable-process-isolated-sandboxed-iframes-by-default.patch
+++ b/patches/0042-enable-process-isolated-sandboxed-iframes-by-default.patch
@@ -1,0 +1,23 @@
+From 556ed9170e49b780ad9ea2460aa773d69356912d Mon Sep 17 00:00:00 2001
+From: June <june@eridan.me>
+Date: Sun, 8 May 2022 01:34:58 +0000
+Subject: [PATCH] enable process isolated sandboxed iframes by default
+
+Signed-off-by: June <june@eridan.me>
+---
+ content/public/common/content_features.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
+index 7dd8a5c6a6e4e..ee15bc696f027 100644
+--- a/content/public/common/content_features.cc
++++ b/content/public/common/content_features.cc
+@@ -459,7 +459,7 @@ const char kIsolateOriginsFieldTrialParamName[] = "OriginsList";
+ // the attribute. Note: At present, only iframes with origin-restricted
+ // sandboxes are isolated.
+ const base::Feature kIsolateSandboxedIframes{"IsolateSandboxedIframes",
+-                                             base::FEATURE_DISABLED_BY_DEFAULT};
++                                             base::FEATURE_ENABLED_BY_DEFAULT};
+ 
+ const base::Feature kLazyFrameLoading{"LazyFrameLoading",
+                                       base::FEATURE_ENABLED_BY_DEFAULT};


### PR DESCRIPTION
Solves https://github.com/Hexavalent-Browser/Hexavalent/issues/72 and https://github.com/Hexavalent-Browser/Hexavalent/issues/102

The current behaviour for sandboxed iframes (the HTML attribute `sandbox` for `iframe`) and all other iframes are that they run in the same process as mentioned in the comments here: https://source.chromium.org/chromium/chromium/src/+/main:content/public/common/content_features.cc;l=449-454?q=IsolateSandboxedIframes&ss=chromium%2Fchromium%2Fsrc

This will allow iframes with the `sandbox` attribute to run in separate processes now. The behaviour for non-`sandbox` iframes is unchanged.

Relevant discussion about site isolation and iframes: https://bugs.chromium.org/p/chromium/issues/detail?id=510122